### PR TITLE
build: add macro for fallthrough annotation 

### DIFF
--- a/beerocks/bcl/include/beerocks/bcl/beerocks_defines.h
+++ b/beerocks/bcl/include/beerocks/bcl/beerocks_defines.h
@@ -26,6 +26,14 @@ namespace beerocks {
 #define BEEROCKS_PLAT_MGR_UDS "uds_platform_manager"
 #define BEEROCKS_BACKHAUL_MGR_UDS "uds_backhaul_manager"
 
+#if __GNUC__ > 4
+#define FALLTHROUGH [[fallthrough]]
+#else
+#define FALLTHROUGH                                                                                \
+    do {                                                                                           \
+    } while (0)
+#endif
+
 namespace message {
 
 enum eStructsConsts {


### PR DESCRIPTION
-Elaborate:
fixing the bug inserted in this commit:
prplfoundation/prplMesh-controller@73403dc

the [fallthrough] annotation is only supported in new compilers, so this
fix is recplacing it with a macro based on the compiler version.

Signed-off-by: Lior Amram <lior.amram@intel.com>