### PR TITLE
logging: Add runtime syslog support configuration

### DIFF
--- a/beerocks/bcl/include/beerocks/bcl/beerocks_config_file.h
+++ b/beerocks/bcl/include/beerocks/bcl/beerocks_config_file.h
@@ -24,6 +24,7 @@ public:
         std::string global_levels;
         std::string syslog_levels;
         std::string global_size;
+        std::string syslog_enabled;
         std::string netlog_host;
         std::string netlog_port;
     };

--- a/beerocks/bcl/include/beerocks/bcl/beerocks_logging.h
+++ b/beerocks/bcl/include/beerocks/bcl/beerocks_logging.h
@@ -89,6 +89,7 @@ public:
     std::string get_log_max_size_setting();
     log_levels get_log_levels();
     log_levels get_syslog_levels();
+    std::string get_syslog_enabled();
 
     void set_log_level_state(const eLogLevel &log_level, const bool &new_state);
 
@@ -109,6 +110,7 @@ protected:
 
 private:
     static const std::string format;
+    static const std::string syslogFormat;
 
     std::string m_module_name;
 
@@ -119,6 +121,7 @@ private:
     log_levels m_syslog_levels;
     std::string m_netlog_host;
     uint16_t m_netlog_port;
+    std::string m_syslog_enabled;
 
     settings_t m_settings_map;
 };

--- a/beerocks/bcl/source/beerocks_config_file.cpp
+++ b/beerocks/bcl/source/beerocks_config_file.cpp
@@ -25,6 +25,7 @@ static bool read_log_section(std::string config_file_path, config_file::SConfigL
         std::make_tuple("log_global_levels=", &sLogConf.global_levels, mandatory),
         std::make_tuple("log_global_syslog_levels=", &sLogConf.syslog_levels, mandatory),
         std::make_tuple("log_global_size=", &sLogConf.global_size, mandatory),
+        std::make_tuple("log_syslog_enabled=", &sLogConf.syslog_enabled, optional),
         std::make_tuple("log_netlog_host=", &sLogConf.netlog_host, optional),
         std::make_tuple("log_netlog_port=", &sLogConf.netlog_port, optional)};
 


### PR DESCRIPTION
Elaborate:
-Add syslog configuration to allow turning syslog writing on/off in runtime.
-Based on the change in this PR:
 prplfoundation/prplMesh-framework#13

Test:
build + testing logs on ubuntu, ugw and rdkb

Signed-off-by: Lior Amram <lior.amram@intel.com>